### PR TITLE
Helpers for packing/unpacking structured data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,15 @@ script:
   - go test -v -run TestRecvUntil
   - go test -v -run TestRecvN
   - go test -v -run TestSend
+  - go test -v -run TestPackUint64LE
+  - go test -v -run TestPackUint32LE
+  - go test -v -run TestPackUint16LE
+  - go test -v -run TestPackUint64BE
+  - go test -v -run TestPackUint32BE
+  - go test -v -run TestPackUint16BE
+  - go test -v -run TestUnpackUint64LE
+  - go test -v -run TestUnpackUint32LE
+  - go test -v -run TestUnpackUint16LE
+  - go test -v -run TestUnpackUint64BE
+  - go test -v -run TestUnpackUint32BE
+  - go test -v -run TestUnpackUint16BE

--- a/asm_test.go
+++ b/asm_test.go
@@ -5,7 +5,6 @@ import (
     "encoding/hex"
 )
 
-// TestDisasm tests disassembly logic
 func TestDisasm(t *testing.T) {
     t.Logf("Testing disassembly (%s)...", elfFile)
     addr := uint64(0x1135)
@@ -32,7 +31,6 @@ func TestDisasm(t *testing.T) {
     t.Log("\n" + disasm)
 }
 
-// TestAsmX8664 tests compilation of x86-64 assembly
 func TestAsmX8664(t *testing.T) {
     code := "mov rdi, 1337\nmov rsi, 1337\nmov rdx, 1337\nmov rcx, 1337\nnop\n"
     t.Logf("Testing assembly of following x86-64 instructions:\n%s", code)
@@ -49,7 +47,6 @@ func TestAsmX8664(t *testing.T) {
     t.Logf("Assembly code compiled to %v bytes:\n%s", len(opcodes), hex.Dump(opcodes))
 }
 
-// TestAsmARM tests compilation of ARM assembly
 func TestAsmARM(t *testing.T) {
     code := "mov r2, r1\nmov r3, r4\nmov r5, r6\n"
     t.Logf("Testing assembly of following ARM instructions:\n%s", code)

--- a/elf_test.go
+++ b/elf_test.go
@@ -8,7 +8,6 @@ import (
 
 var elfFile = "test/prog1.x86_64"
 
-// TestNewELF tests instantiation of the ELF object and detection of mitigations
 func TestNewELF(t *testing.T) {
     t.Logf("Testing ELF processing (%s)...", elfFile)
     e, err := NewELF(elfFile)
@@ -42,7 +41,6 @@ func TestNewELF(t *testing.T) {
     t.Log("Canary: " + strconv.FormatBool(e.Mitigations.Canary))
 }
 
-// TestELFBSS tests relative addressing in the BSS section
 func TestELFBSS(t *testing.T) {
     t.Logf("Testing .bss section addressing (%s)...", elfFile)
     e, _ := NewELF(elfFile)
@@ -57,7 +55,6 @@ func TestELFBSS(t *testing.T) {
     t.Logf(".bss+4 == 0x%08x", addr)
 }
 
-// TestELFRead tests reading data from an ELF at a specified virtual address
 func TestELFRead(t *testing.T) {
     t.Logf("Testing ELF vaddr reads (%s)...", elfFile)
     e, _ := NewELF(elfFile)
@@ -74,7 +71,6 @@ func TestELFRead(t *testing.T) {
     t.Logf("Read %v bytes from vaddr:0x%08x:\n%s", readSize, addr, hex.Dump(data))
 }
 
-// TestELFGetSignatureVAddrs test searching for bytes in all segments
 func TestELFGetSignatureVAddrs(t *testing.T) {
     t.Logf("Testing ELF binary signature search")
     e, _ := NewELF(elfFile)
@@ -88,7 +84,6 @@ func TestELFGetSignatureVAddrs(t *testing.T) {
     }
 }
 
-// TestELFGetOpcodeVAddrs tests searching for bytes in executable segments
 func TestELFGetOpcodeVAddrs(t *testing.T) {
     leaRDI := []byte{0x48, 0x8d, 0x3d, 0xb9, 0x0e, 0x00, 0x00}
     e, _ := NewELF(elfFile)
@@ -102,7 +97,6 @@ func TestELFGetOpcodeVAddrs(t *testing.T) {
     }
 }
 
-// TestRead8 tests reading 8-bit integers from an ELF
 func TestRead8(t *testing.T) {
     e, _ := NewELF(elfFile)
     i8, err := e.Read16LE(0x2c4)
@@ -115,7 +109,6 @@ func TestRead8(t *testing.T) {
     }
 }
 
-// TestRead16 tests reading 16-bit integers from an ELF
 func TestRead16(t *testing.T) {
     t.Logf("Testing 16-bit integer reads (%s)...", elfFile)
     e, _ := NewELF(elfFile)
@@ -138,7 +131,6 @@ func TestRead16(t *testing.T) {
     }
 }
 
-// TestRead32 tests reading 32-bit integers from an ELF
 func TestRead32(t *testing.T) {
     t.Logf("Testing 32-bit integer reads (%s)...", elfFile)
     e, _ := NewELF(elfFile)
@@ -161,7 +153,6 @@ func TestRead32(t *testing.T) {
     }
 }
 
-// TestRead64 tests reading 64-bit integers from an ELF
 func TestRead64(t *testing.T) {
     t.Logf("Testing 64-bit integer reads (%s)...", elfFile)
     e, _ := NewELF(elfFile)

--- a/remote_test.go
+++ b/remote_test.go
@@ -6,7 +6,6 @@ import(
     "testing"
 )
 
-// TestRecvLine tests receiving a line of data from a TCP server
 func TestRecvLine(t *testing.T) {
     go func() {
         time.Sleep(500 * time.Millisecond)
@@ -40,7 +39,6 @@ func TestRecvLine(t *testing.T) {
     conn.Write([]byte("lolwut\n"))
 }
 
-// TestRecvUntil tests receiving until a specified sequence of bytes
 func TestRecvUntil(t *testing.T) {
     go func() {
         time.Sleep(500 * time.Millisecond)
@@ -75,7 +73,6 @@ func TestRecvUntil(t *testing.T) {
     conn.Write([]byte("cmd>"))
 }
 
-// TestRecvN tests receiving a specified number of bytes
 func TestRecvN(t *testing.T) {
     go func() {
         time.Sleep(500 * time.Millisecond)
@@ -109,7 +106,6 @@ func TestRecvN(t *testing.T) {
     conn.Write([]byte("lolwut"))
 }
 
-// TestSend tests sending data using Remote's Send and SendLine methods
 func TestSend(t *testing.T) {
     go func() {
         time.Sleep(500 * time.Millisecond)

--- a/rop_test.go
+++ b/rop_test.go
@@ -5,7 +5,6 @@ import (
     "bytes"
 )
 
-// TestELFDumpROPGadgets tests ROP gadget dumping functionality
 func TestROPDump(t *testing.T) {
     t.Logf("Testing ROP gadget dump (%s)...", elfFile)
     e, _ := NewELF(elfFile)
@@ -16,7 +15,6 @@ func TestROPDump(t *testing.T) {
     r.Dump()
 }
 
-// TestROPInstrSearch tests searching for ROP gadgets by regex
 func TestROPInstrSearch(t *testing.T) {
     t.Logf("Testing ROP gadget search (%s)...", elfFile)
     e, _ := NewELF(elfFile)

--- a/struct.go
+++ b/struct.go
@@ -1,0 +1,77 @@
+package sploit;
+
+import(
+    "encoding/binary"
+)
+
+// PackUint64LE packs a uint64 into a byte slice in little endian format
+func PackUint64LE(i uint64) []byte {
+    b := make([]byte, 8)
+    binary.LittleEndian.PutUint64(b, i)
+    return b
+}
+
+// PackUint32LE packs a uint32 into a byte slice in little endian format
+func PackUint32LE(i uint32) []byte {
+    b := make([]byte, 4)
+    binary.LittleEndian.PutUint32(b, i)
+    return b
+}
+
+// PackUint16LE packs a uint16 into a byte slice in little endian format
+func PackUint16LE(i uint16) []byte {
+    b := make([]byte, 2)
+    binary.LittleEndian.PutUint16(b, i)
+    return b
+}
+
+// PackUint64BE packs a uint64 into a byte slice in big endian format
+func PackUint64BE(i uint64) []byte {
+    b := make([]byte, 8)
+    binary.BigEndian.PutUint64(b, i)
+    return b
+}
+
+// PackUint32BE packs a uint32 into a byte slice in big endian format
+func PackUint32BE(i uint32) []byte {
+    b := make([]byte, 4)
+    binary.BigEndian.PutUint32(b, i)
+    return b
+}
+
+// PackUint16BE packs a uint16 into a byte slice in big endian format
+func PackUint16BE(i uint16) []byte {
+    b := make([]byte, 2)
+    binary.BigEndian.PutUint16(b, i)
+    return b
+}
+
+// UnpackUint64LE unpacks a byte slice in little endian format into a uint64
+func UnpackUint64LE(b []byte) uint64 {
+    return binary.LittleEndian.Uint64(b)
+}
+
+// UnpackUint32LE unpacks a byte slice in little endian format into a uint32
+func UnpackUint32LE(b []byte) uint32 {
+    return binary.LittleEndian.Uint32(b)
+}
+
+// UnpackUint16LE unpacks a byte slice in little endian format into a uint16
+func UnpackUint16LE(b []byte) uint16 {
+    return binary.LittleEndian.Uint16(b)
+}
+
+// UnpackUint64BE unpacks a byte slice in big endian format into a uint64
+func UnpackUint64BE(b []byte) uint64 {
+    return binary.BigEndian.Uint64(b)
+}
+
+// UnpackUint32BE unpacks a byte slice in big endian format into a uint32
+func UnpackUint32BE(b []byte) uint32 {
+    return binary.BigEndian.Uint32(b)
+}
+
+// UnpackUint16BE unpacks a byte slice in big endian format into a uint16
+func UnpackUint16BE(b []byte) uint16 {
+    return binary.BigEndian.Uint16(b)
+}

--- a/struct_test.go
+++ b/struct_test.go
@@ -1,0 +1,78 @@
+package sploit;
+
+import (
+    "testing"
+    "bytes"
+)
+
+func TestPackUint64LE(t *testing.T) {
+    if bytes.Compare(PackUint64LE(0xf00bdeadbeeff00b), []byte{0x0b, 0xf0, 0xef, 0xbe, 0xad, 0xde, 0x0b, 0xf0}) != 0 {
+        t.Fatal("Return bytes != expected")
+    }
+}
+
+func TestPackUint32LE(t *testing.T) {
+    if bytes.Compare(PackUint32LE(0xf00bdead), []byte{0xad, 0xde, 0x0b, 0xf0}) != 0 {
+        t.Fatal("Return bytes != expected")
+    }
+}
+
+func TestPackUint16LE(t *testing.T) {
+    if bytes.Compare(PackUint16LE(0xf00b), []byte{0x0b, 0xf0}) != 0 {
+        t.Fatal("Return bytes != expected")
+    }
+}
+
+func TestPackUint64BE(t *testing.T) {
+    if bytes.Compare(PackUint64BE(0xf00bdeadbeeff00b), []byte{0xf0, 0x0b, 0xde, 0xad, 0xbe, 0xef, 0xf0, 0x0b}) != 0 {
+        t.Fatal("Return bytes != expected")
+    }
+}
+
+func TestPackUint32BE(t *testing.T) {
+    if bytes.Compare(PackUint32BE(0xf00bdead), []byte{0xf0, 0x0b, 0xde, 0xad}) != 0 {
+        t.Fatal("Return bytes != expected")
+    }
+}
+
+func TestPackUint16BE(t *testing.T) {
+    if bytes.Compare(PackUint16BE(0xf00b), []byte{0xf0, 0x0b}) != 0 {
+        t.Fatal("Return bytes != expected")
+    }
+}
+
+func TestUnpackUint64LE(t *testing.T) {
+    if UnpackUint64LE([]byte{0x0b, 0xf0, 0xef, 0xbe, 0xad, 0xde, 0x0b, 0xf0}) != 0xf00bdeadbeeff00b {
+        t.Fatal("Return value != expected")
+    }
+}
+
+func TestUnpackUint32LE(t *testing.T) {
+    if UnpackUint32LE([]byte{0x0b, 0xf0, 0xef, 0xbe}) != 0xbeeff00b {
+        t.Fatal("Return value != expected")
+    }
+}
+
+func TestUnpackUint16LE(t *testing.T) {
+    if UnpackUint16LE([]byte{0x0b, 0xf0}) != 0xf00b {
+        t.Fatal("Return value != expected")
+    }
+}
+
+func TestUnpackUint64BE(t *testing.T) {
+    if UnpackUint64BE([]byte{0xf0, 0x0b, 0xde, 0xad, 0xbe, 0xef, 0xf0, 0x0b}) != 0xf00bdeadbeeff00b {
+        t.Fatal("Return value != expected")
+    }
+}
+
+func TestUnpackUint32BE(t *testing.T) {
+    if UnpackUint32BE([]byte{0xf0, 0x0b, 0xde, 0xad}) != 0xf00bdead {
+        t.Fatal("Return value != expected")
+    }
+}
+
+func TestUnpackUint16BE(t *testing.T) {
+    if UnpackUint16BE([]byte{0xf0, 0x0b}) != 0xf00b {
+        t.Fatal("Return value != expected")
+    }
+}


### PR DESCRIPTION
Wrote struct.go to wrap encoding/binary routines to reduce syntax
required to use PutUint* and Uint*

Closes #20