### PR TITLE
Methods for patching ELF files

### DIFF
--- a/_examples/patch_elf.go
+++ b/_examples/patch_elf.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	sp "github.com/zznop/sploit"
+)
+
+var origProgram = "../test/prog1.x86_64"
+var patchedProgram = "./patched"
+
+var patchInstrs = `
+jmp past
+
+message:
+    .ascii "This is an example patch payload\n"
+
+past:
+    mov rdi, 1                    /* STDOUT file descriptor */
+    lea rsi, [rip + message]      /* Pointer to message string */
+    mov rdx, 33                   /* Message size */
+    mov rax, 1                    /* __NR_write */
+    syscall                       /* Execute system call */
+self:
+    jmp self                      /* Hang forever */
+`
+
+func main() {
+	e, _ := sp.NewELF(origProgram)
+
+	fmt.Printf("Patching _start of %v\n", origProgram)
+	e.AsmPatch(patchInstrs, 0x1050)
+
+	fmt.Printf("Exporting patched ELF to %v\n", patchedProgram)
+	e.Save(patchedProgram, 0777)
+}

--- a/elf.go
+++ b/elf.go
@@ -19,7 +19,7 @@ type ELF struct {
 	raw         []byte
 }
 
-// NewELF loads a ELF file from disk and initializes the ELF struct
+// NewELF loads an ELF file from disk and initializes the ELF struct
 func NewELF(filename string) (*ELF, error) {
 	f, err := os.Open(filename)
 	if err != nil {
@@ -81,7 +81,22 @@ func (e *ELF) OffsetToAddr(offset uint64) (uint64, error) {
 	return 0, errors.New("Offset is not in range of an ELF segment")
 }
 
-// BSS is an ELF method that returns the virtual address of the specified offset into the .bss section
+// AddrToOffset determines the offset for the specified virtual address
+func (e *ELF) AddrToOffset(address uint64) (uint64, error) {
+	for i := 0; i < len(e.E.Progs); i++ {
+		s := e.E.Progs[i]
+		start := s.Vaddr
+		end := s.Vaddr + s.Filesz
+
+		if address >= start && address < end {
+			return address - s.Vaddr + s.Off, nil
+		}
+	}
+
+	return 0, errors.New("Address is not in range of an ELF segment")
+}
+
+// BSS returns the virtual address of the specified offset into the .bss section
 func (e *ELF) BSS(offset uint64) (uint64, error) {
 	section := e.E.Section(".bss")
 	if section == nil {
@@ -95,7 +110,7 @@ func (e *ELF) BSS(offset uint64) (uint64, error) {
 	return section.Addr + offset, nil
 }
 
-// Read is an ELF method that returns a slice of bytes read from the ELF at the specified virtual address
+// Read returns a slice of bytes read from the ELF at the specified virtual address
 func (e *ELF) Read(address uint64, nBytes int) ([]byte, error) {
 	s, err := getVASegment(e.E, address)
 	if err != nil {
@@ -116,7 +131,7 @@ func (e *ELF) Read(address uint64, nBytes int) ([]byte, error) {
 	return buf, nil
 }
 
-// Read8 is an ELF method that reads 8 bits from the ELF at the specified address and returns the data as a uint8
+// Read8 reads 8 bits from the ELF at the specified address and returns the data as a uint8
 func (e *ELF) Read8(address uint64) (uint8, error) {
 	b, err := e.readIntBytes(address, 1)
 	if err != nil {
@@ -126,7 +141,7 @@ func (e *ELF) Read8(address uint64) (uint8, error) {
 	return b[0], nil
 }
 
-// Read16LE is an ELF method that reads 16 bits from the ELF at the specified address and returns a Uint16 in little endian byte order
+// Read16LE reads 16 bits from the ELF at the specified address and returns a Uint16 in little endian byte order
 func (e *ELF) Read16LE(address uint64) (uint16, error) {
 	b, err := e.readIntBytes(address, 2)
 	if err != nil {
@@ -136,7 +151,7 @@ func (e *ELF) Read16LE(address uint64) (uint16, error) {
 	return binary.LittleEndian.Uint16(b), nil
 }
 
-// Read16BE is an ELF method that reads 16 bits from the ELF at the specified address and returns a Uint16 in big endian byte order
+// Read16BE reads 16 bits from the ELF at the specified address and returns a Uint16 in big endian byte order
 func (e *ELF) Read16BE(address uint64) (uint16, error) {
 	b, err := e.readIntBytes(address, 2)
 	if err != nil {
@@ -146,7 +161,7 @@ func (e *ELF) Read16BE(address uint64) (uint16, error) {
 	return binary.BigEndian.Uint16(b), nil
 }
 
-// Read32LE is an ELF method that reads 32 bits from the ELF at the specified address and returns a Uint32 in little endian byte order
+// Read32LE reads 32 bits from the ELF at the specified address and returns a Uint32 in little endian byte order
 func (e *ELF) Read32LE(address uint64) (uint32, error) {
 	b, err := e.readIntBytes(address, 4)
 	if err != nil {
@@ -156,7 +171,7 @@ func (e *ELF) Read32LE(address uint64) (uint32, error) {
 	return binary.LittleEndian.Uint32(b), nil
 }
 
-// Read32BE is an ELF method that reads 32 bits from the ELF at the specified address and returns a Uint32 in big endian byte order
+// Read32BE reads 32 bits from the ELF at the specified address and returns a Uint32 in big endian byte order
 func (e *ELF) Read32BE(address uint64) (uint32, error) {
 	b, err := e.readIntBytes(address, 4)
 	if err != nil {
@@ -166,7 +181,7 @@ func (e *ELF) Read32BE(address uint64) (uint32, error) {
 	return binary.BigEndian.Uint32(b), nil
 }
 
-// Read64LE is an ELF method that reads 64 bits from the ELF at the specified address and returns a Uint64 in little endian byte order
+// Read64LE reads 64 bits from the ELF at the specified address and returns a Uint64 in little endian byte order
 func (e *ELF) Read64LE(address uint64) (uint64, error) {
 	b, err := e.readIntBytes(address, 8)
 	if err != nil {
@@ -176,7 +191,7 @@ func (e *ELF) Read64LE(address uint64) (uint64, error) {
 	return binary.LittleEndian.Uint64(b), nil
 }
 
-// Read64BE is an ELF method that reads 64 bits from the ELF at the specified address and returns a Uint64 in big endian byte order
+// Read64BE reads 64 bits from the ELF at the specified address and returns a Uint64 in big endian byte order
 func (e *ELF) Read64BE(address uint64) (uint64, error) {
 	b, err := e.readIntBytes(address, 8)
 	if err != nil {
@@ -186,7 +201,7 @@ func (e *ELF) Read64BE(address uint64) (uint64, error) {
 	return binary.BigEndian.Uint64(b), nil
 }
 
-// Disasm is an ELF method that disassembles code at the specified virtual address and returns a string containing assembly instructions
+// Disasm disassembles code at the specified virtual address and returns a string containing assembly instructions
 func (e *ELF) Disasm(address uint64, nBytes int) (string, error) {
 	data, err := e.Read(address, nBytes)
 	if err != nil {
@@ -198,7 +213,7 @@ func (e *ELF) Disasm(address uint64, nBytes int) (string, error) {
 	return disasm(data, address, arch, mode, false)
 }
 
-// ROP is an ELF method that locates all ROP gadgets in the ELF's executable segments and returns a ROP object
+// ROP locates all ROP gadgets in the ELF's executable segments and returns a ROP object
 func (e *ELF) ROP() (*ROP, error) {
 	file := e.E
 	gadgets := ROP{}
@@ -226,19 +241,40 @@ func (e *ELF) ROP() (*ROP, error) {
 	return &gadgets, nil
 }
 
-// GetSignatureVAddrs is an ELF method that searches for the specified sequence of bytes in all segments
+// GetSignatureVAddrs searches for the specified sequence of bytes in all segments
 func (e *ELF) GetSignatureVAddrs(signature []byte) ([]uint64, error) {
 	return e.getSignatureVAddrs(signature, false)
 }
 
-// GetOpcodeVAddrs is an ELF method that searches for the specified sequence of bytes in executable segments only
+// GetOpcodeVAddrs searches for the specified sequence of bytes in executable segments only
 func (e *ELF) GetOpcodeVAddrs(signature []byte) ([]uint64, error) {
 	return e.getSignatureVAddrs(signature, true)
 }
 
-// Save is a ELF method for saving the raw ELF content to a specified file path
+// Save saves the raw ELF content to a specified file path
 func (e *ELF) Save(filePath string, fileMode os.FileMode) error {
 	return ioutil.WriteFile(filePath, e.raw, fileMode)
+}
+
+// RawPatch copies data to the in-memory raw ELF data at the specified virtual address
+func (e *ELF) RawPatch(data []byte, address uint64) error {
+	offset, err := e.AddrToOffset(address)
+	if err != nil {
+		return err
+	}
+
+	copy(e.raw[offset:offset+uint64(len(data))], data)
+	return nil
+}
+
+// AsmPatch compiles an assembly patch and writes it to the in-memory raw ELF data at the specified virtual address
+func (e *ELF) AsmPatch(code string, address uint64) error {
+	opcode, err := Asm(e.Processor, code)
+	if err != nil {
+		return err
+	}
+
+	return e.RawPatch(opcode, address)
 }
 
 func (e *ELF) getSignatureVAddrs(signature []byte, exeOnly bool) ([]uint64, error) {
@@ -283,7 +319,7 @@ func getVASegment(e *elf.File, address uint64) (*elf.Prog, error) {
 		}
 	}
 
-	return nil, errors.New("Address is not in range of a ELF section")
+	return nil, errors.New("Address is not in range of an ELF section")
 }
 
 func getArchInfo(e *elf.File) (*Processor, error) {

--- a/elf.go
+++ b/elf.go
@@ -131,6 +131,52 @@ func (e *ELF) Read(address uint64, nBytes int) ([]byte, error) {
 	return buf, nil
 }
 
+// Write copies data to the in-memory raw ELF data at the specified virtual address
+func (e *ELF) Write(data []byte, address uint64) error {
+	offset, err := e.AddrToOffset(address)
+	if err != nil {
+		return err
+	}
+
+	copy(e.raw[offset:offset+uint64(len(data))], data)
+	return nil
+}
+
+// Write8 copies a uint8 to the in-memory ELF data at the specified address
+func (e *ELF) Write8(i uint8, address uint64) error {
+	return e.Write([]byte{i}, address)
+}
+
+// Write16LE copies a uint16 (little endian) to the in-memory ELF data at the specified address
+func (e *ELF) Write16LE(i uint16, address uint64) error {
+	return e.Write(PackUint16LE(i), address)
+}
+
+// Write16BE copies a uint16 (big endian) to the in-memory ELF data at the specified address
+func (e *ELF) Write16BE(i uint16, address uint64) error {
+	return e.Write(PackUint16BE(i), address)
+}
+
+// Write32LE copies a uint32 (little endian) to the in-memory ELF data at the specified address
+func (e *ELF) Write32LE(i uint32, address uint64) error {
+	return e.Write(PackUint32LE(i), address)
+}
+
+// Write32BE copies a uint32 (big endian) to the in-memory ELF data at the specified address
+func (e *ELF) Write32BE(i uint32, address uint64) error {
+	return e.Write(PackUint32BE(i), address)
+}
+
+// Write64LE copies a uint64 (little endian) to the in-memory ELF data at the specified address
+func (e *ELF) Write64LE(i uint64, address uint64) error {
+	return e.Write(PackUint64LE(i), address)
+}
+
+// Write64BE copies a uint64 (big endian) to the in-memory ELF data at the specified address
+func (e *ELF) Write64BE(i uint64, address uint64) error {
+	return e.Write(PackUint64BE(i), address)
+}
+
 // Read8 reads 8 bits from the ELF at the specified address and returns the data as a uint8
 func (e *ELF) Read8(address uint64) (uint8, error) {
 	b, err := e.readIntBytes(address, 1)
@@ -256,17 +302,6 @@ func (e *ELF) Save(filePath string, fileMode os.FileMode) error {
 	return ioutil.WriteFile(filePath, e.raw, fileMode)
 }
 
-// RawPatch copies data to the in-memory raw ELF data at the specified virtual address
-func (e *ELF) RawPatch(data []byte, address uint64) error {
-	offset, err := e.AddrToOffset(address)
-	if err != nil {
-		return err
-	}
-
-	copy(e.raw[offset:offset+uint64(len(data))], data)
-	return nil
-}
-
 // AsmPatch compiles an assembly patch and writes it to the in-memory raw ELF data at the specified virtual address
 func (e *ELF) AsmPatch(code string, address uint64) error {
 	opcode, err := Asm(e.Processor, code)
@@ -274,7 +309,7 @@ func (e *ELF) AsmPatch(code string, address uint64) error {
 		return err
 	}
 
-	return e.RawPatch(opcode, address)
+	return e.Write(opcode, address)
 }
 
 func (e *ELF) getSignatureVAddrs(signature []byte, exeOnly bool) ([]uint64, error) {

--- a/elf.go
+++ b/elf.go
@@ -66,7 +66,7 @@ func NewELF(filename string) (*ELF, error) {
 	}, nil
 }
 
-// OffsetToVA determines the virtual address for the specified file offset
+// OffsetToAddr determines the virtual address for the specified file offset
 func (e *ELF) OffsetToAddr(offset uint64) (uint64, error) {
 	for i := 0; i < len(e.E.Progs); i++ {
 		s := e.E.Progs[i]

--- a/elf_test.go
+++ b/elf_test.go
@@ -187,29 +187,36 @@ func TestELFSave(t *testing.T) {
 	os.Remove(filePath)
 }
 
-func TestELFRawPatch(t *testing.T) {
+func TestELFWrite(t *testing.T) {
 	t.Log("Testing ELF raw patch...")
 	e1, _ := NewELF(elfFile)
-	err := e1.RawPatch([]byte{0x41, 0x41, 0x41, 0x41}, 0x2f0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	e1.Write([]byte{0x41, 0x41, 0x41, 0x41}, 0x2f0)
+	e1.Write8(0x42, 0x2f4)
+	e1.Write16LE(0xf00b, 0x2f5)
+	e1.Write16BE(0xf00b, 0x2f7)
+	e1.Write32LE(0xfeedface, 0x2f9)
+	e1.Write32BE(0xfeedface, 0x2fd)
+	e1.Write64LE(0xdeadbeefdeadbeef, 0x301)
+	e1.Write64BE(0xdeadbeefdeadbeef, 0x309)
 
 	filePath := "/tmp/test_raw_patch"
-	err = e1.Save(filePath, 0777)
+	err := e1.Save(filePath, 0777)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(filePath)
 
 	e2, _ := NewELF(filePath)
-	i32, err := e2.Read32LE(0x2f0)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if i32 != 0x41414141 {
-		t.Fatal(err)
+	data, _ := e2.Read32LE(0x2f0)
+	i8, _ := e2.Read8(0x2f4)
+	i16, _ := e2.Read16LE(0x2f5)
+	i16BE, _ := e2.Read16BE(0x2f7)
+	i32, _ := e2.Read32LE(0x2f9)
+	i32BE, _ := e2.Read32BE(0x2fd)
+	i64, _ := e2.Read64LE(0x301)
+	i64BE, _ := e2.Read64BE(0x309)
+	if data != 0x41414141 || i8 != 0x42 || i16 != 0xf00b || i16BE != 0xf00b || i32 != 0xfeedface || i32BE != 0xfeedface || i64 != 0xdeadbeefdeadbeef || i64BE != 0xdeadbeefdeadbeef {
+		t.Fatal("read data != expected")
 	}
 }
 

--- a/elf_test.go
+++ b/elf_test.go
@@ -186,3 +186,55 @@ func TestELFSave(t *testing.T) {
 	}
 	os.Remove(filePath)
 }
+
+func TestELFRawPatch(t *testing.T) {
+	t.Log("Testing ELF raw patch...")
+	e1, _ := NewELF(elfFile)
+	err := e1.RawPatch([]byte{0x41, 0x41, 0x41, 0x41}, 0x2f0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	filePath := "/tmp/test_raw_patch"
+	err = e1.Save(filePath, 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(filePath)
+
+	e2, _ := NewELF(filePath)
+	i32, err := e2.Read32LE(0x2f0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if i32 != 0x41414141 {
+		t.Fatal(err)
+	}
+}
+
+func TestELFAsmPatch(t *testing.T) {
+	t.Log("Testing ELF assembly patch...")
+	e1, _ := NewELF(elfFile)
+	err := e1.AsmPatch("nop\nnop\nnop\nnop\n", 0x1135)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	filePath := "/tmp/test_asm_patch"
+	err = e1.Save(filePath, 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(filePath)
+
+	e2, _ := NewELF(filePath)
+	i32, err := e2.Read32LE(0x1135)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if i32 != 0x90909090 {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR adds functionality to apply patches to ELF files by supplying integer types, byte slices, or assembly code

Closes #31 